### PR TITLE
Constants refactor with open loop sim drive fix

### DIFF
--- a/src/main/java/frc/lib/constants/AutoConstants.java
+++ b/src/main/java/frc/lib/constants/AutoConstants.java
@@ -12,68 +12,26 @@ import frc.lib.constants.DriveConstants;
  * 
  * @author Sammcdo, EliSauder, JoeyFabel, Shueja, AriShashivkopanazak
  */
-public abstract class AutoConstants {
-      /**
-       * The SimpleMotorFeedForward for the drivebase gearboxes.
-       */
-      protected SimpleMotorFeedforward TRAJECTORY_FEED_FORWARD;
-      /**
-       * The voltage constraint for the drive motors.
-       */
-      protected DifferentialDriveVoltageConstraint AUTO_VOLTAGE_CONSTRAINT;
-      /**
-       * The centripetal acceleration constraint for the drive motors.
-       */
-      protected CentripetalAccelerationConstraint CENTRIPETAL_ACCELERATION_CONSTRAINT;
-      /**
-       * The trajectory following config for the drivebase
-       */
-      protected TrajectoryConfig TRAJECTORY_CONFIG;
-      /**
-       * The Ramsete controller for trajectory following.
-       */
-      protected RamseteController RAMSETE_CONTROLLER;
-      /**
-       * The DriveConstants to provide info about the drivebase.
-       */
-      protected DriveConstants driveConstants;
+public interface AutoConstants {
 
-      /**
-       * Creates a new AutoConstants class
-       * @param drivebaseConstants The drive constants to use.
-       */
-      public AutoConstants(DriveConstants drivebaseConstants){
-            driveConstants = drivebaseConstants;
-      }
       /**
        * The maximum acceleration, in m/s^2
        * @return The max acceleration
        */
-      public abstract double getkMaxAccelerationMetersPerSecondSquared();
-      public abstract double getkMaxSpeedMetersPerSecond();
-      public abstract double getkRamseteB();
-      public abstract double getkRamseteZeta();
+      public double getkMaxAccelerationMetersPerSecondSquared();
+      public double getkMaxSpeedMetersPerSecond();
+      public double getkRamseteB();
+      public double getkRamseteZeta();
 
       /**
        * The SimpleMotorFeedForward object for trajectory generation on the talon.
        */
-      public SimpleMotorFeedforward getTrajectoryFeedForward() {
-            return TRAJECTORY_FEED_FORWARD;
-      }
+      public SimpleMotorFeedforward getTrajectoryFeedForward();
+      public DifferentialDriveVoltageConstraint getAutoVoltageConstraint();
       
-      public DifferentialDriveVoltageConstraint getAutoVoltageConstraint() {
-            return AUTO_VOLTAGE_CONSTRAINT;
-      }
+      public CentripetalAccelerationConstraint getAutoCentripetalConstraint();
       
-      public CentripetalAccelerationConstraint getAutoCentripetalConstraint() {
-            return CENTRIPETAL_ACCELERATION_CONSTRAINT;
-      }
+      public TrajectoryConfig getTrajectoryConfig();
       
-      public TrajectoryConfig getTrajectoryConfig() {
-            return TRAJECTORY_CONFIG;
-      }
-      
-      public RamseteController getRamseteController() {
-            return RAMSETE_CONTROLLER;
-      }
+      public RamseteController getRamseteController();
 }

--- a/src/main/java/frc/lib/constants/DriveConstants.java
+++ b/src/main/java/frc/lib/constants/DriveConstants.java
@@ -25,92 +25,102 @@ import edu.wpi.first.wpiutil.math.numbers.N7;
  * 
  * @author Shueja
  */
-public abstract class DriveConstants {
+public interface DriveConstants {
     /**
      * The DifferentialDriveKinematics for the drivebase, based on the track width.
      */
-    protected DifferentialDriveKinematics kDifferentialDriveKinematics = new DifferentialDriveKinematics(getkTrackWidthMeters());
+    /*protected DifferentialDriveKinematics kDifferentialDriveKinematics = new DifferentialDriveKinematics(getkTrackWidthMeters());*/
     /**
      * The drivetrain model, based on the characterization constants.
      */
-    protected LinearSystem<N2, N2, N2> kDrivetrainPlant = 
+    /*protected LinearSystem<N2, N2, N2> kDrivetrainPlant = 
         LinearSystemId.identifyDrivetrainSystem(
         getKvVoltSecondsPerMeter(),
         getKaVoltSecondsSquaredPerMeter(),
         getKvVoltSecondsPerRadian(),
-        getKaVoltSecondsSquaredPerRadian());
+        getKaVoltSecondsSquaredPerRadian());*/
     /**
      * The custom axis ID that will be used for the driving forward/back speed.
      * @return the axis id, defaults to 33
      */
-    public int getDriveControllerFwdBackAxis() {
-        return 33;
-    }
+    public int getDriveControllerFwdBackAxis();
     /**
      * The custom axis ID that will be used for the driving turning.
      * @return the axis id, defaults to 34
      */
-    public int getDriveControllerLeftRightAxis() {
-        return 34;
-    }
+    public int getDriveControllerLeftRightAxis() ;
     /** The CAN ID for the left master motor controller. */
-    public int getCanIDLeftDriveMaster() {
-        return 10;
-    }
-    public abstract boolean getLeftEncoderReversed();
-    public abstract int[] getLeftEncoderPorts();
+    public int getCanIDLeftDriveMaster();
+    public boolean getLeftEncoderReversed();
+    public int[] getLeftEncoderPorts();
     /** The CAN ID for the right master motor controller. */
-    public abstract int getCanIDRightDriveMaster();
-    public abstract boolean getRightEncoderReversed();
-    public abstract int[] getRightEncoderPorts();
+    public int getCanIDRightDriveMaster();
+    public boolean getRightEncoderReversed();
+    public int[] getRightEncoderPorts();
     /** The CAN ID for the left follower motor controller. */
-    public abstract int getCanIDLeftDriveFollower();
+    public int getCanIDLeftDriveFollower();
 
     /** The CAN ID for the right follower motor controller. */
-    public abstract int getCanIDRightDriveFollower();
+    public int getCanIDRightDriveFollower();
 
     /** Whether or not the gyro is reversed */
-    public abstract boolean getGyroReversed();
+    public boolean getGyroReversed();
 
     /** The number of encoder counts per encoder revolution. */
-    public abstract double getEncoderCountsPerEncoderRevolution();
+    public double getEncoderCountsPerEncoderRevolution();
 
     /**
      * The number of encoder counts per wheel revolution (7 encoder revolutions per
      * 3 wheel revolutions).
      */
-    public double getEncoderCountsPerWheelRevolution() {
+    public double getEncoderCountsPerWheelRevolution();/* {
         return getEncoderCountsPerEncoderRevolution() *
-        getEncoderRevolutionsPerWheelRevolution();}
+        getEncoderRevolutionsPerWheelRevolution();}*/
 
-    public abstract double getEncoderRevolutionsPerWheelRevolution();
-    public double getEncoderDistancePerPulse() {
+    public double getEncoderRevolutionsPerWheelRevolution();
+    public double getEncoderDistancePerPulse(); /* {
         return (getkWheelDiameter() * Math.PI) / (double) getEncoderCountsPerEncoderRevolution();
-    }
+    }*/
     // Drive characterization DriveConstants
 
-    public abstract double getKsVolts();
-    public abstract double getKvVoltSecondsPerMeter();
-    public abstract double getKaVoltSecondsSquaredPerMeter();
-    public abstract double getKvVoltSecondsPerRadian();
-    public abstract double getKaVoltSecondsSquaredPerRadian();
-    public abstract double getkWheelDiameter();
+    public double getKsVolts();
+    public double getKvVoltSecondsPerMeter();
+    public double getKaVoltSecondsSquaredPerMeter();
+    public double getKvVoltSecondsPerRadian();
+    public double getKaVoltSecondsSquaredPerRadian();
+    public double getkWheelDiameter();
 
-    public abstract double getkPDriveVel();
-    public abstract double getkPDriveVelLeft();
-    public abstract double getkPDriveVelRight();
-    public abstract double getkTrackWidthMeters();
+    public double getkPDriveVel();
+    public double getkPDriveVelLeft();
+    public double getkPDriveVelRight();
+    public double getkTrackWidthMeters();
 
-    public DifferentialDriveKinematics getDifferentialDriveKinematics() {
+    public DifferentialDriveKinematics getDifferentialDriveKinematics(); /* {
         return kDifferentialDriveKinematics;
-    }
-    public LinearSystem<N2, N2, N2> getDrivetrainPlant(){
+    }*/
+    public LinearSystem<N2, N2, N2> getDrivetrainPlant();/*{
         return kDrivetrainPlant;
-    }
-    public abstract DCMotor getDriveGearbox();
+    }*/
+    public DCMotor getDriveGearbox();
 
-    public abstract double getDriveGearingRatio();
+    public double getDriveGearingRatio();
 
-    public abstract Vector<N7> getSimEncoderStdDev();
+    public Vector<N7> getSimEncoderStdDev();
+
+       /**
+     * 
+     * @return The value to multiply the drive controller forward back axis by 
+     */
+    public int getDriveControllerFwdBackAxisMultiplier();
+    /**
+     * 
+     * @return The value to multiply the drive controller turning axis by
+     */
+    public int getDriveControllerLeftRightAxisMultiplier();
+
+    /**
+     * 
+     */
+    public boolean getDrivebaseRightSideInverted();
     
 }   

--- a/src/main/java/frc/lib/wrappers/inputdevices/NomadAxis.java
+++ b/src/main/java/frc/lib/wrappers/inputdevices/NomadAxis.java
@@ -35,7 +35,7 @@ public class NomadAxis {
    * @param id
    */
   public NomadAxis(int id) {
-      super();
+      
       this.id = id;
   }
 
@@ -45,7 +45,7 @@ public class NomadAxis {
    * @param axisName The name.
    */
   public NomadAxis(int id, String axisName) {
-      super();
+      
       this.id = id;
       name = axisName;
   }
@@ -57,7 +57,7 @@ public class NomadAxis {
      * @param customAxisBehavior A function that returns the axis value.
      */
     public NomadAxis(int id, String axisName, DoubleSupplier customAxisBehavior) {
-        super();
+        
         this.id = id;
         name = axisName;
         customBehavior = customAxisBehavior;

--- a/src/main/java/frc/lib/wrappers/motorcontrollers/NomadTalonSRX.java
+++ b/src/main/java/frc/lib/wrappers/motorcontrollers/NomadTalonSRX.java
@@ -33,9 +33,6 @@ public class NomadTalonSRX extends WPI_TalonSRX implements NomadBaseMotor {
     protected double lastLeaderOutput = Double.NaN;
     protected double currentLeaderOutput = Double.NaN;
     /**
-     * A quadrature NomadEncoder connected to the Talon.
-     */
-    /**
      * Constructs a TalonSRX, reverts it to factory default, and sets brake mode.
      * 
      * @param port The CAN ID of this Talon

--- a/src/main/java/frc/lib/wrappers/motorcontrollers/NomadTalonSRX.java
+++ b/src/main/java/frc/lib/wrappers/motorcontrollers/NomadTalonSRX.java
@@ -5,7 +5,16 @@ import com.ctre.phoenix.motorcontrol.IMotorController;
 import com.ctre.phoenix.motorcontrol.NeutralMode;
 import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX;
 
+import edu.wpi.first.hal.SimDevice;
+import edu.wpi.first.hal.SimDouble;
+import edu.wpi.first.hal.SimDevice.Direction;
+import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.wpilibj.RobotBase;
+import edu.wpi.first.wpilibj.networktables.NetworkTable;
+import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
+import edu.wpi.first.wpilibj.smartdashboard.SendableRegistry;
+import frc.lib.constants.DriveConstants;
+import frc.lib.utility.math.NomadUnits;
 
 /**
  * This class is an encapsulation of WPI_TalonSRX that add a couple constructors
@@ -13,6 +22,7 @@ import edu.wpi.first.wpilibj.RobotBase;
  * FRC 254.
  */
 public class NomadTalonSRX extends WPI_TalonSRX implements NomadBaseMotor {
+
     /** This decides if the talon should operate in lazy mode. */
     protected boolean lazy = false;
     protected NomadBaseMotor leader = NomadNoneMotor.noneMotor;
@@ -22,7 +32,9 @@ public class NomadTalonSRX extends WPI_TalonSRX implements NomadBaseMotor {
     protected boolean manualFollowing = false;
     protected double lastLeaderOutput = Double.NaN;
     protected double currentLeaderOutput = Double.NaN;
-
+    /**
+     * A quadrature NomadEncoder connected to the Talon.
+     */
     /**
      * Constructs a TalonSRX, reverts it to factory default, and sets brake mode.
      * 
@@ -140,5 +152,11 @@ public class NomadTalonSRX extends WPI_TalonSRX implements NomadBaseMotor {
         } else {
             return get();
         }
+    }
+
+    @Override
+    public void initSendable(SendableBuilder builder) {
+        // TODO Auto-generated method stub
+        super.initSendable(builder);
     }
 }

--- a/src/main/java/frc/template/NomadInputMaps.java
+++ b/src/main/java/frc/template/NomadInputMaps.java
@@ -71,11 +71,11 @@ public class NomadInputMaps {
         map.withAxis(
             //new NomadAxis(id, axisName, customAxisBehavior)
             new NomadAxis(driveConstants.getDriveControllerFwdBackAxis(), "FWD/BACK", (DoubleSupplier) () -> {
-                return driveConstants.getDriveControllerFwdBackAxisMultiplier() * map.getRawAxis(NomadOperatorConsole.getCombinedID(DriverStationConstants.DRIVER_CONTROLLER_USB_PORT, XboxController.Axis.kLeftY.value));
+                return driveConstants.getDriveControllerFwdBackAxisMultiplier() * NomadOperatorConsole.getRawAxis(NomadOperatorConsole.getCombinedID(DriverStationConstants.DRIVER_CONTROLLER_USB_PORT, XboxController.Axis.kLeftY.value));
             }))
         .withAxis(
             new NomadAxis(driveConstants.getDriveControllerLeftRightAxis(), "LEFT/RIGHT", (DoubleSupplier) () -> {
-                return driveConstants.getDriveControllerLeftRightAxisMultiplier() * map.getRawAxis(XboxController.Axis.kLeftX.value);
+                return driveConstants.getDriveControllerLeftRightAxisMultiplier() * NomadOperatorConsole.getRawAxis(XboxController.Axis.kLeftX.value);
             }));
         return map;
     }

--- a/src/main/java/frc/template/NomadInputMaps.java
+++ b/src/main/java/frc/template/NomadInputMaps.java
@@ -71,11 +71,11 @@ public class NomadInputMaps {
         map.withAxis(
             //new NomadAxis(id, axisName, customAxisBehavior)
             new NomadAxis(driveConstants.getDriveControllerFwdBackAxis(), "FWD/BACK", (DoubleSupplier) () -> {
-                return NomadOperatorConsole.getRawAxis(NomadOperatorConsole.getCombinedID(DriverStationConstants.DRIVER_CONTROLLER_USB_PORT, XboxController.Axis.kLeftY.value));
+                return driveConstants.getDriveControllerFwdBackAxisMultiplier() * map.getRawAxis(NomadOperatorConsole.getCombinedID(DriverStationConstants.DRIVER_CONTROLLER_USB_PORT, XboxController.Axis.kLeftY.value));
             }))
         .withAxis(
             new NomadAxis(driveConstants.getDriveControllerLeftRightAxis(), "LEFT/RIGHT", (DoubleSupplier) () -> {
-                return NomadOperatorConsole.getRawAxis(XboxController.Axis.kLeftX.value);
+                return driveConstants.getDriveControllerLeftRightAxisMultiplier() * map.getRawAxis(XboxController.Axis.kLeftX.value);
             }));
         return map;
     }

--- a/src/main/java/frc/template/constants/AutoConstantsDefault.java
+++ b/src/main/java/frc/template/constants/AutoConstantsDefault.java
@@ -7,40 +7,104 @@
 
 package frc.template.constants;
 
+import edu.wpi.first.wpilibj.controller.RamseteController;
+import edu.wpi.first.wpilibj.controller.SimpleMotorFeedforward;
+import edu.wpi.first.wpilibj.trajectory.TrajectoryConfig;
+import edu.wpi.first.wpilibj.trajectory.constraint.CentripetalAccelerationConstraint;
+import edu.wpi.first.wpilibj.trajectory.constraint.DifferentialDriveVoltageConstraint;
 import frc.lib.constants.AutoConstants;
 import frc.lib.constants.DriveConstants;
 
 /**
  * Add your docs here.
  */
-public class AutoConstantsDefault extends AutoConstants{
-    
+public class AutoConstantsDefault implements AutoConstants {
+        /**
+       * The SimpleMotorFeedForward for the drivebase gearboxes.
+       */
+      protected SimpleMotorFeedforward TRAJECTORY_FEED_FORWARD;
+      /**
+       * The voltage constraint for the drive motors.
+       */
+      protected DifferentialDriveVoltageConstraint AUTO_VOLTAGE_CONSTRAINT;
+      /**
+       * The centripetal acceleration constraint for the drive motors.
+       */
+      protected CentripetalAccelerationConstraint CENTRIPETAL_ACCELERATION_CONSTRAINT;
+      /**
+       * The trajectory following config for the drivebase
+       */
+      protected TrajectoryConfig TRAJECTORY_CONFIG;
+      /**
+       * The Ramsete controller for trajectory following.
+       */
+      protected RamseteController RAMSETE_CONTROLLER;
+      /**
+       * The DriveConstants to provide info about the drivebase.
+       */
+      protected DriveConstants driveConstants;
+
+      /**
+       * Creates a new AutoConstants class
+       * @param drivebaseConstants The drive constants to use.
+       */
+
     public AutoConstantsDefault(DriveConstants drivebaseConstants) {
-        super(drivebaseConstants);
         // TODO Auto-generated constructor stub
+        driveConstants = drivebaseConstants;
     }
 
     @Override
     public double getkMaxAccelerationMetersPerSecondSquared() {
-        
+
         return 0;
     }
 
     @Override
     public double getkMaxSpeedMetersPerSecond() {
-        
+
         return 0;
     }
 
     @Override
     public double getkRamseteB() {
-        
+
         return 0;
     }
 
     @Override
     public double getkRamseteZeta() {
-        
+
         return 0;
+    }
+
+    @Override
+    public SimpleMotorFeedforward getTrajectoryFeedForward() {
+        // TODO Auto-generated method stub
+        return TRAJECTORY_FEED_FORWARD;
+    }
+
+    @Override
+    public DifferentialDriveVoltageConstraint getAutoVoltageConstraint() {
+        // TODO Auto-generated method stub
+        return AUTO_VOLTAGE_CONSTRAINT;
+    }
+
+    @Override
+    public CentripetalAccelerationConstraint getAutoCentripetalConstraint() {
+        // TODO Auto-generated method stub
+        return CENTRIPETAL_ACCELERATION_CONSTRAINT;
+    }
+
+    @Override
+    public TrajectoryConfig getTrajectoryConfig() {
+        // TODO Auto-generated method stub
+        return TRAJECTORY_CONFIG;
+    }
+
+    @Override
+    public RamseteController getRamseteController() {
+        // TODO Auto-generated method stub
+        return RAMSETE_CONTROLLER;
     }
 }

--- a/src/main/java/frc/template/constants/AutoConstantsDemoAuto.java
+++ b/src/main/java/frc/template/constants/AutoConstantsDemoAuto.java
@@ -6,14 +6,40 @@ package frc.template.constants;
 
 import frc.lib.constants.AutoConstants;
 import frc.lib.constants.DriveConstants;
+import edu.wpi.first.wpilibj.controller.RamseteController;
 import edu.wpi.first.wpilibj.controller.SimpleMotorFeedforward;
 import edu.wpi.first.wpilibj.trajectory.TrajectoryConfig;
+import edu.wpi.first.wpilibj.trajectory.constraint.CentripetalAccelerationConstraint;
 import edu.wpi.first.wpilibj.trajectory.constraint.DifferentialDriveVoltageConstraint;
 
 /** Add your docs here. */
-public class AutoConstantsDemoAuto extends AutoConstants {
-    public AutoConstantsDemoAuto(DriveConstants driveConstants) {
-        super(driveConstants);
+public class AutoConstantsDemoAuto implements AutoConstants {
+          /**
+       * The SimpleMotorFeedForward for the drivebase gearboxes.
+       */
+      protected SimpleMotorFeedforward TRAJECTORY_FEED_FORWARD;
+      /**
+       * The voltage constraint for the drive motors.
+       */
+      protected DifferentialDriveVoltageConstraint AUTO_VOLTAGE_CONSTRAINT;
+      /**
+       * The centripetal acceleration constraint for the drive motors.
+       */
+      protected CentripetalAccelerationConstraint CENTRIPETAL_ACCELERATION_CONSTRAINT;
+      /**
+       * The trajectory following config for the drivebase
+       */
+      protected TrajectoryConfig TRAJECTORY_CONFIG;
+      /**
+       * The Ramsete controller for trajectory following.
+       */
+      protected RamseteController RAMSETE_CONTROLLER;
+      /**
+       * The DriveConstants to provide info about the drivebase.
+       */
+      protected DriveConstants driveConstants;
+    public AutoConstantsDemoAuto(DriveConstants drivebaseConstants) {
+        driveConstants = drivebaseConstants;
         TRAJECTORY_FEED_FORWARD = new SimpleMotorFeedforward(
             driveConstants.getKsVolts(),
             driveConstants.getKvVoltSecondsPerMeter(),
@@ -34,6 +60,8 @@ public class AutoConstantsDemoAuto extends AutoConstants {
             .setKinematics(driveConstants.getDifferentialDriveKinematics())
             // Apply the voltage constraint
             .addConstraint(AUTO_VOLTAGE_CONSTRAINT);
+
+        RAMSETE_CONTROLLER = new RamseteController(getkRamseteB(), getkRamseteZeta());
 
     // An example trajectory to follow.  All units in meters.
     
@@ -61,6 +89,35 @@ public class AutoConstantsDemoAuto extends AutoConstants {
     public double getkRamseteZeta() {
         
         return 0.7;
+    }
+    @Override
+    public SimpleMotorFeedforward getTrajectoryFeedForward() {
+        // TODO Auto-generated method stub
+        return TRAJECTORY_FEED_FORWARD;
+    }
+
+    @Override
+    public DifferentialDriveVoltageConstraint getAutoVoltageConstraint() {
+        // TODO Auto-generated method stub
+        return AUTO_VOLTAGE_CONSTRAINT;
+    }
+
+    @Override
+    public CentripetalAccelerationConstraint getAutoCentripetalConstraint() {
+        // TODO Auto-generated method stub
+        return CENTRIPETAL_ACCELERATION_CONSTRAINT;
+    }
+
+    @Override
+    public TrajectoryConfig getTrajectoryConfig() {
+        // TODO Auto-generated method stub
+        return TRAJECTORY_CONFIG;
+    }
+
+    @Override
+    public RamseteController getRamseteController() {
+        // TODO Auto-generated method stub
+        return RAMSETE_CONTROLLER;
     }
 
 }

--- a/src/main/java/frc/template/constants/AutoConstantsKRen.java
+++ b/src/main/java/frc/template/constants/AutoConstantsKRen.java
@@ -13,9 +13,35 @@ import frc.lib.constants.DriveConstants;
  * 
  * @author Sammcdo, EliSauder, JoeyFabel, Shueja, AriShashivkopanazak
  */
-public class AutoConstantsKRen extends AutoConstants{
+public class AutoConstantsKRen implements AutoConstants{
+
+              /**
+       * The SimpleMotorFeedForward for the drivebase gearboxes.
+       */
+      protected SimpleMotorFeedforward TRAJECTORY_FEED_FORWARD;
+      /**
+       * The voltage constraint for the drive motors.
+       */
+      protected DifferentialDriveVoltageConstraint AUTO_VOLTAGE_CONSTRAINT;
+      /**
+       * The centripetal acceleration constraint for the drive motors.
+       */
+      protected CentripetalAccelerationConstraint CENTRIPETAL_ACCELERATION_CONSTRAINT;
+      /**
+       * The trajectory following config for the drivebase
+       */
+      protected TrajectoryConfig TRAJECTORY_CONFIG;
+      /**
+       * The Ramsete controller for trajectory following.
+       */
+      protected RamseteController RAMSETE_CONTROLLER;
+      /**
+       * The DriveConstants to provide info about the drivebase.
+       */
+      protected DriveConstants driveConstants;
+
       public AutoConstantsKRen(final DriveConstants drivebaseConstants) {
-            super(drivebaseConstants);
+            driveConstants = drivebaseConstants;
             //Create the objects to be returned.
             TRAJECTORY_FEED_FORWARD = new SimpleMotorFeedforward(
                   driveConstants.getKsVolts(), driveConstants.getKvVoltSecondsPerMeter(),
@@ -52,5 +78,35 @@ public class AutoConstantsKRen extends AutoConstants{
       @Override
       public double getkRamseteZeta() {
             return 0.7;
+      }
+
+      @Override
+      public SimpleMotorFeedforward getTrajectoryFeedForward() {
+          // TODO Auto-generated method stub
+          return TRAJECTORY_FEED_FORWARD;
+      }
+  
+      @Override
+      public DifferentialDriveVoltageConstraint getAutoVoltageConstraint() {
+          // TODO Auto-generated method stub
+          return AUTO_VOLTAGE_CONSTRAINT;
+      }
+  
+      @Override
+      public CentripetalAccelerationConstraint getAutoCentripetalConstraint() {
+          // TODO Auto-generated method stub
+          return CENTRIPETAL_ACCELERATION_CONSTRAINT;
+      }
+  
+      @Override
+      public TrajectoryConfig getTrajectoryConfig() {
+          // TODO Auto-generated method stub
+          return TRAJECTORY_CONFIG;
+      }
+  
+      @Override
+      public RamseteController getRamseteController() {
+          // TODO Auto-generated method stub
+          return RAMSETE_CONTROLLER;
       }
 }

--- a/src/main/java/frc/template/constants/DriveConstantsDefault.java
+++ b/src/main/java/frc/template/constants/DriveConstantsDefault.java
@@ -8,16 +8,32 @@
 package frc.template.constants;
 
 import edu.wpi.first.wpilibj.kinematics.DifferentialDriveKinematics;
+import edu.wpi.first.wpilibj.system.LinearSystem;
 import edu.wpi.first.wpilibj.system.plant.DCMotor;
+import edu.wpi.first.wpilibj.system.plant.LinearSystemId;
 import frc.lib.constants.DriveConstants;
 import edu.wpi.first.wpiutil.math.VecBuilder;
 import edu.wpi.first.wpiutil.math.Vector;
+import edu.wpi.first.wpiutil.math.numbers.N2;
 import edu.wpi.first.wpiutil.math.numbers.N7;
 
 /**
  * Add your docs here.
  */
-public class DriveConstantsDefault extends DriveConstants {
+public class DriveConstantsDefault implements DriveConstants {
+    /**
+     * The DifferentialDriveKinematics for the drivebase, based on the track width.
+     */
+    protected DifferentialDriveKinematics kDifferentialDriveKinematics = new DifferentialDriveKinematics(getkTrackWidthMeters());
+    /**
+     * The drivetrain model, based on the characterization constants.
+     */
+    protected LinearSystem<N2, N2, N2> kDrivetrainPlant = 
+        LinearSystemId.identifyDrivetrainSystem(
+        getKvVoltSecondsPerMeter(),
+        getKaVoltSecondsSquaredPerMeter(),
+        getKvVoltSecondsPerRadian(),
+        getKaVoltSecondsSquaredPerRadian());
 
     @Override
     public int getCanIDLeftDriveMaster() {
@@ -181,5 +197,35 @@ public class DriveConstantsDefault extends DriveConstants {
     @Override
     public Vector<N7> getSimEncoderStdDev() {
         return VecBuilder.fill(0, 0, 0, 0, 0, 0, 0);
+    }
+
+    @Override
+    public double getEncoderDistancePerPulse() {
+        // TODO Auto-generated method stub
+        return 0;
+    }
+
+    @Override
+    public LinearSystem<N2, N2, N2> getDrivetrainPlant() {
+        // TODO Auto-generated method stub
+        return kDrivetrainPlant;
+    }
+
+    @Override
+    public int getDriveControllerFwdBackAxisMultiplier() {
+        // TODO Auto-generated method stub
+        return 1;
+    }
+
+    @Override
+    public int getDriveControllerLeftRightAxisMultiplier() {
+        // TODO Auto-generated method stub
+        return 1;
+    }
+
+    @Override
+    public boolean getDrivebaseRightSideInverted() {
+        // TODO Auto-generated method stub
+        return false;
     }
 }

--- a/src/main/java/frc/template/constants/DriveConstantsDemoAuto.java
+++ b/src/main/java/frc/template/constants/DriveConstantsDemoAuto.java
@@ -5,15 +5,31 @@
 package frc.template.constants;
 
 import edu.wpi.first.wpilibj.kinematics.DifferentialDriveKinematics;
+import edu.wpi.first.wpilibj.system.LinearSystem;
 import edu.wpi.first.wpilibj.system.plant.DCMotor;
+import edu.wpi.first.wpilibj.system.plant.LinearSystemId;
 import edu.wpi.first.wpilibj.util.Units;
 import edu.wpi.first.wpiutil.math.VecBuilder;
 import edu.wpi.first.wpiutil.math.Vector;
+import edu.wpi.first.wpiutil.math.numbers.N2;
 import edu.wpi.first.wpiutil.math.numbers.N7;
 import frc.lib.constants.DriveConstants;
 
 /** Add your docs here. */
-public class DriveConstantsDemoAuto extends DriveConstants {
+public class DriveConstantsDemoAuto implements DriveConstants {
+        /**
+     * The DifferentialDriveKinematics for the drivebase, based on the track width.
+     */
+    protected DifferentialDriveKinematics kDifferentialDriveKinematics = new DifferentialDriveKinematics(getkTrackWidthMeters());
+    /**
+     * The drivetrain model, based on the characterization constants.
+     */
+    protected LinearSystem<N2, N2, N2> kDrivetrainPlant = 
+        LinearSystemId.identifyDrivetrainSystem(
+        getKvVoltSecondsPerMeter(),
+        getKaVoltSecondsSquaredPerMeter(),
+        getKvVoltSecondsPerRadian(),
+        getKaVoltSecondsSquaredPerRadian());
 
     @Override
     public int getDriveControllerFwdBackAxis() {
@@ -172,5 +188,47 @@ public class DriveConstantsDemoAuto extends DriveConstants {
         // l and r velocity: 0.1 m/s
         // l and r position: 0.005 m
         return VecBuilder.fill(0.0001, 0.0001, 0.0001, 0.01, 0.01, 0.0005, 0.0005);
+    }
+
+    @Override
+    public double getEncoderCountsPerWheelRevolution() {
+        // TODO Auto-generated method stub
+        return getEncoderCountsPerEncoderRevolution() *
+        getEncoderRevolutionsPerWheelRevolution();
+    }
+
+    @Override
+    public double getEncoderDistancePerPulse() {
+        // TODO Auto-generated method stub
+        return (getkWheelDiameter() * Math.PI) / (double) getEncoderCountsPerEncoderRevolution();
+    }
+
+    @Override
+    public DifferentialDriveKinematics getDifferentialDriveKinematics() {
+        // TODO Auto-generated method stub
+        return kDifferentialDriveKinematics;
+    }
+
+    @Override
+    public LinearSystem<N2, N2, N2> getDrivetrainPlant() {
+        // TODO Auto-generated method stub
+        return kDrivetrainPlant;
+    }
+
+       /**
+     * 
+     * @return The value to multiply the drive controller forward back axis by 
+     */
+    public int getDriveControllerFwdBackAxisMultiplier() { return -1;}
+    /**
+     * 
+     * @return The value to multiply the drive controller turning axis by
+     */
+    public int getDriveControllerLeftRightAxisMultiplier() {return 1;}
+
+    @Override
+    public boolean getDrivebaseRightSideInverted() {
+    // TODO Auto-generated method stub
+    return true;
     }
 }

--- a/src/main/java/frc/template/constants/DriveConstantsKRen.java
+++ b/src/main/java/frc/template/constants/DriveConstantsKRen.java
@@ -3,6 +3,7 @@ package frc.template.constants;
 import edu.wpi.first.wpilibj.kinematics.DifferentialDriveKinematics;
 import edu.wpi.first.wpilibj.system.LinearSystem;
 import edu.wpi.first.wpilibj.system.plant.DCMotor;
+import edu.wpi.first.wpilibj.system.plant.LinearSystemId;
 import edu.wpi.first.wpiutil.math.Vector;
 import edu.wpi.first.wpiutil.math.numbers.N2;
 import edu.wpi.first.wpiutil.math.numbers.N7;
@@ -11,7 +12,20 @@ import frc.lib.constants.DriveConstants;
 /**
  * Drive Constants for our 2020 bot KRen
  */
-public final class DriveConstantsKRen extends DriveConstants {
+public final class DriveConstantsKRen implements DriveConstants {
+    /**
+     * The DifferentialDriveKinematics for the drivebase, based on the track width.
+     */
+    protected DifferentialDriveKinematics kDifferentialDriveKinematics = new DifferentialDriveKinematics(getkTrackWidthMeters());
+    /**
+     * The drivetrain model, based on the characterization constants.
+     */
+    protected LinearSystem<N2, N2, N2> kDrivetrainPlant = 
+        LinearSystemId.identifyDrivetrainSystem(
+        getKvVoltSecondsPerMeter(),
+        getKaVoltSecondsSquaredPerMeter(),
+        getKvVoltSecondsPerRadian(),
+        getKaVoltSecondsSquaredPerRadian());
     @Override
     /** The CAN ID for the left master motor controller. */
     public int getCanIDLeftDriveMaster() {
@@ -92,11 +106,9 @@ public final class DriveConstantsKRen extends DriveConstants {
         return 0.6032;
     }
 
-    public final DifferentialDriveKinematics kDriveKinematics = new DifferentialDriveKinematics(getkTrackWidthMeters());
-
     @Override
     public DifferentialDriveKinematics getDifferentialDriveKinematics() {
-        return kDriveKinematics;
+        return kDifferentialDriveKinematics;
     }
 
     @Override
@@ -165,5 +177,35 @@ public final class DriveConstantsKRen extends DriveConstants {
     @Override
     public Vector<N7> getSimEncoderStdDev() {
         return null;
+    }
+
+    @Override
+    public double getEncoderDistancePerPulse() {
+        // TODO Auto-generated method stub
+        return 0;
+    }
+
+    @Override
+    public LinearSystem<N2, N2, N2> getDrivetrainPlant() {
+        // TODO Auto-generated method stub
+        return kDrivetrainPlant;
+    }
+
+    @Override
+    public int getDriveControllerFwdBackAxisMultiplier() {
+        // TODO Auto-generated method stub
+        return 1;
+    }
+
+    @Override
+    public int getDriveControllerLeftRightAxisMultiplier() {
+        // TODO Auto-generated method stub
+        return 1;
+    }
+
+    @Override
+    public boolean getDrivebaseRightSideInverted() {
+        // TODO Auto-generated method stub
+        return false;
     }
 }

--- a/src/main/java/frc/template/subsystems/AutonomousDrivebaseS.java
+++ b/src/main/java/frc/template/subsystems/AutonomousDrivebaseS.java
@@ -30,7 +30,7 @@ public class AutonomousDrivebaseS extends DifferentialDrivebaseS {
   private NomadTalonSRX leftLeader;
   private NomadTalonSRX rightLeader;
 
-  private DifferentialDrive m_drive;
+  //private DifferentialDrive m_drive;
 
   private Encoder m_leftEncoder;
   private Encoder m_rightEncoder;
@@ -55,7 +55,7 @@ public class AutonomousDrivebaseS extends DifferentialDrivebaseS {
     leftLeader = new NomadTalonSRX(driveConstants.getCanIDLeftDriveMaster());
     rightLeader = new NomadTalonSRX(driveConstants.getCanIDRightDriveMaster());
 
-    m_drive = new DifferentialDrive(leftLeader, rightLeader);
+    //m_drive = new DifferentialDrive(leftLeader, rightLeader);
 
     m_leftEncoder = new Encoder(driveConstants.getLeftEncoderPorts()[0], driveConstants.getLeftEncoderPorts()[1],
         driveConstants.getLeftEncoderReversed());
@@ -97,7 +97,7 @@ public class AutonomousDrivebaseS extends DifferentialDrivebaseS {
     // the [-1, 1] PWM signal to voltage by multiplying it by the
     // robot controller voltage.
     m_driveSim.setInputs(leftLeader.get() * RobotController.getInputVoltage(),
-        -rightLeader.get() * RobotController.getInputVoltage());
+    (driveConstants.getDrivebaseRightSideInverted() ? -1 : 1) * rightLeader.get() * RobotController.getInputVoltage());
 
     // Advance the model by 20 ms. Note that if you are running this
     // subsystem in a separate thread or have changed the nominal timestep
@@ -146,8 +146,8 @@ public class AutonomousDrivebaseS extends DifferentialDrivebaseS {
 
   @Override
   public void drivePercentages(DrivebaseWheelPercentages percentages) {
-    leftLeader.set(ControlMode.PercentOutput, percentages.getLeftPercentage());
-    rightLeader.set(ControlMode.PercentOutput, percentages.getRightPercentage());
+    leftLeader.set(percentages.getLeftPercentage());
+    rightLeader.set((driveConstants.getDrivebaseRightSideInverted() ? -1 : 1) * percentages.getRightPercentage());
   }
 
   @Override
@@ -193,8 +193,8 @@ public class AutonomousDrivebaseS extends DifferentialDrivebaseS {
       rightVolts *= batteryVoltage / 12.0;
     }
     leftLeader.setVoltage(leftVolts);
-    rightLeader.setVoltage(-rightVolts);
-    m_drive.feed();
+    rightLeader.setVoltage((driveConstants.getDrivebaseRightSideInverted() ? -1 : 1) * rightVolts);
+    //m_drive.feed();
   }
 
   @Override


### PR DESCRIPTION
Signed-off-by: shueja-personal <j.a.shue@outlook.com>
Closes #37 
Also includes the constants changes needed to properly drive the robot in open loop sim. For future reference, drivePercentages() called the Talon set() directly (the one with control mode), which bypasses the Speedcontroller things that drive sim pulls from.